### PR TITLE
Fix rowview does not show reserved device

### DIFF
--- a/rowview.php
+++ b/rowview.php
@@ -32,7 +32,7 @@
 
 		if($config->ParameterArray["ReservedColor"] != "#FFFFFF" || $config->ParameterArray["FreeSpaceColor"] != "#FFFFFF"){
 			$head.="		<style type=\"text/css\">
-			.reserved{background-color: {$config->ParameterArray['ReservedColor']};}
+			.reserved{background-color: {$config->ParameterArray['ReservedColor']} !important;}
 			.freespace{background-color: {$config->ParameterArray['FreeSpaceColor']};}\n";
 		}
 


### PR DESCRIPTION
Added !important to CSS for reserved class as the department class went before reserved causing the reserved color not to be shown.